### PR TITLE
oracledb resultset

### DIFF
--- a/oracleDriver.js
+++ b/oracleDriver.js
@@ -16,7 +16,7 @@ module.exports = function () {
     outstandingQueries: outstandingQueries(),
 
     query: function (query, params, options) {
-      var resultsPromise = this.execute(replaceParameters(query), params, _.extend({outFormat: oracledb.ARRAY}, options));
+      var resultsPromise = this.execute(replaceParameters(query), params, _.extend({outFormat: oracledb.ARRAY}, options))
 
       if (options.statement || options.insert) {
         return resultsPromise.then(function (results) {
@@ -72,6 +72,12 @@ module.exports = function () {
         stream.on('metadata', function (md) {
           metadata = md
         })
+      }).catch(function (e) {
+        if (/NJS-019/.test(e.message)) {
+          throw new Error('oracle: you cannot pass an SQL statement to db.query(), please use db.statement()')
+        } else {
+          throw e
+        }
       })
     },
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chai-as-promised": "5.3.0",
     "es6-promise": "3.2.1",
     "fs-promise": "0.5.0",
-    "mocha": "2.5.3",
+    "mocha": "^3.2.0",
     "mssql": "3.3.0",
     "mysql": "2.11.1",
     "pg": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "chai-as-promised": "5.3.0",
     "es6-promise": "3.2.1",
     "fs-promise": "0.5.0",
-    "mocha": "^3.2.0",
+    "mocha": "3.2.0",
     "mssql": "3.3.0",
     "mysql": "2.11.1",
     "pg": "6.1.0",

--- a/readme.md
+++ b/readme.md
@@ -247,6 +247,8 @@ sworm.db(url)
   See: [getConnection()](https://github.com/oracle/node-oracledb/blob/master/doc/api.md#-332-getconnection)
   For `options` see [Oracledb Properties](https://github.com/oracle/node-oracledb/blob/master/doc/api.md#oracledbproperties)
 
+  The driver fetches `maxRows` rows at a time, defaulting to 100. You may want to adjust this value if you expect large result sets, higher values can be faster but use more memory.
+
   The driver will use connection pooling if you pass `pool: true`.
 
   By default the driver is set to `autoCommit = true`, you can pass `options: { autoCommit: false}` to turn this off again.

--- a/test/describeDatabase.js
+++ b/test/describeDatabase.js
@@ -50,7 +50,7 @@ module.exports = function(name, config, database, otherTests) {
 
         function clearTables() {
           return Promise.all(tables.map(function (table) {
-            return db.query('delete from ' + table);
+            return db.statement('delete from ' + table);
           }));
         }
 
@@ -1196,7 +1196,7 @@ module.exports = function(name, config, database, otherTests) {
 
       describe("connection", function() {
         function clear(db) {
-          return db.query('delete from people');
+          return db.statement('delete from people');
         }
 
         it("can define models before connecting to database", function() {

--- a/test/oracleSpec.js
+++ b/test/oracleSpec.js
@@ -134,6 +134,24 @@ if (!process.env.TRAVIS) {
       });
     });
 
+    describe('passing statements to query()', function () {
+      var db
+
+      beforeEach(function () {
+        db = sworm.db(config());
+      })
+
+      afterEach(function () {
+        if (db) {
+          return db.close()
+        }
+      });
+
+      it('throws error when passing a statement to query()', function () {
+        return expect(db.query('insert into people (name) values (@name)', {name: 'bob'})).to.be.rejectedWith('use db.statement()')
+      })
+    })
+
     describe('connection pooling', function () {
       var db;
       var db1;

--- a/test/oracleSpec.js
+++ b/test/oracleSpec.js
@@ -15,7 +15,7 @@ if (!process.env.TRAVIS) {
     createTables: function(db, tables) {
       function createTable(name, id, sql, noAutoId) {
         tables.push(name);
-        return db.query(
+        return db.statement(
           "BEGIN " +
           "  EXECUTE IMMEDIATE 'DROP TABLE " + name + "'; " +
           "EXCEPTION WHEN OTHERS THEN " +
@@ -24,7 +24,7 @@ if (!process.env.TRAVIS) {
           "  END IF; " +
           "END;"
         ).then(function() {
-          return db.query(
+          return db.statement(
             "BEGIN " +
             "  EXECUTE IMMEDIATE 'DROP SEQUENCE " + name + "_seq'; " +
             "EXCEPTION WHEN OTHERS THEN " +
@@ -34,12 +34,12 @@ if (!process.env.TRAVIS) {
             "END;"
           ).then(function() {
             if (!noAutoId) {
-              return db.query('CREATE SEQUENCE ' + name + '_seq');
+              return db.statement('CREATE SEQUENCE ' + name + '_seq');
             }
           }).then(function() {
-            return db.query(sql).then(function() {
+            return db.statement(sql).then(function() {
               if (!noAutoId) {
-                return db.query(
+                return db.statement(
                   "create or replace trigger " + name + "_id " +
                   "  before insert on " + name + " " +
                   "  for each row " +


### PR DESCRIPTION
~~Use `queryStream()` instead of `execute()`. Works around `maxRows` issue and has identical measurable performance.~~

Use `ResultSet` to download batches of `maxRows` rows. Queries are no longer limited by `maxRows` now, so smaller values of `maxRows` are better, but will still need tweaking for performance.

Only downside is that you can only do SQL queries (`select`) with `db.query()`, for statements (`insert`, `update`, `delete`) have to use `db.statement()`.