### PR TITLE
graph query

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "plugin:es5/no-es2015"
+  ],
+  "rules": {
+    "no-console": "error"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -110,11 +110,18 @@ function graphify(definition, rows) {
     }
   }
 
+  var results = []
+  var resultsSet = new Set()
+
   rows.forEach(function (row) {
-    loadEntity(row, map)
+    var entity = loadEntity(row, map)
+    if (!resultsSet.has(entity)) {
+      results.push(entity)
+      resultsSet.add(entity)
+    }
   })
 
-  return Object.values(map.identityMap)
+  return results
 }
 
 function insertStatement(obj, keys) {

--- a/index.js
+++ b/index.js
@@ -92,7 +92,12 @@ function graphify(definition, rows) {
             if (!array) {
               array = entity[field] = []
             }
-            array.push(foreignEntity)
+            var existing = array.find(function (item) {
+              return item.identity() === foreignEntity.identity()
+            })
+            if (!existing) {
+              array.push(foreignEntity)
+            }
           } else if (!entity[field]) {
             foreignEntity.setForeignKeyField(false)
             entity[field] = foreignEntity

--- a/index.js
+++ b/index.js
@@ -43,14 +43,14 @@ function mapDefinition (graphDefinition) {
 
   var foreignFields = foreignFieldsForObject(model)
 
-  foreignFields.forEach(field => {
+  foreignFields.forEach(function (field) {
     var foreign = model[field]
     model[field] = mapDefinition(foreign)
   })
 
   return {
     model: model,
-    isOneToMany,
+    isOneToMany: isOneToMany,
     identityMap: {}
   }
 }
@@ -76,12 +76,12 @@ function graphify(definition, rows) {
       var entity = map.identityMap[id]
       if (!entity) {
         entity = map.identityMap[id] = map.model._meta.model({}, {saved: true})
-        fields.forEach(field => {
+        fields.forEach(function (field) {
           entity[field] = row[map.model[field]]
         })
       }
 
-      foreignFields.forEach(field => {
+      foreignFields.forEach(function (field) {
         var foreign = map.model[field]
 
         var foreignEntity = loadEntity(row, foreign)
@@ -104,7 +104,7 @@ function graphify(definition, rows) {
     }
   }
 
-  rows.forEach(row => {
+  rows.forEach(function (row) {
     loadEntity(row, map)
   })
 

--- a/mssqlDriver.js
+++ b/mssqlDriver.js
@@ -25,7 +25,7 @@ module.exports = function() {
           }
 
           if (options.insert) {
-            r.id = result[0][options.id]
+            r.id = params.hasOwnProperty(options.id) ? params[options.id] : result[0][options.id]
           }
 
           return r

--- a/mysqlDriver.js
+++ b/mysqlDriver.js
@@ -28,7 +28,7 @@ module.exports = function() {
       }).then(function (result) {
         if (options.insert || options.statement) {
           return {
-            id: result.insertId,
+            id: params.hasOwnProperty(options.id) ? params[options.id] : result.insertId,
             changes: result.affectedRows + result.changedRows
           }
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -603,6 +603,12 @@
         }
       }
     },
+    "eslint-plugin-es5": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es5/-/eslint-plugin-es5-1.1.0.tgz",
+      "integrity": "sha1-KOfv25u8EBPTRrjZlYJ6uaJW7C4=",
+      "dev": true
+    },
     "espree": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "electron-mocha": "4.0.0",
     "electron-rebuild": "1.5.11",
     "es6-promise": "3.2.1",
+    "eslint-plugin-es5": "1.1.0",
     "fs-promise": "0.5.0",
     "mocha": "3.4.2",
     "mssql": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "chai-as-promised": "7.0.0",
     "electron": "1.6.11",
     "electron-mocha": "4.0.0",
+    "electron-rebuild": "1.5.11",
     "es6-promise": "3.2.1",
     "fs-promise": "0.5.0",
     "mocha": "3.4.2",

--- a/sqliteDriver.js
+++ b/sqliteDriver.js
@@ -24,7 +24,10 @@ module.exports = function() {
             if (error) {
               reject(error);
             } else {
-              fulfil({id: this.lastID, changes: this.changes});
+              fulfil({
+                id: params.hasOwnProperty(options.id) ? params[options.id] : this.lastID,
+                changes: this.changes
+              });
             }
           });
         });

--- a/test/browser/websqlSpec.js
+++ b/test/browser/websqlSpec.js
@@ -12,6 +12,10 @@ var database = {
     return createTable("people",
       'create table if not exists people (id integer primary key, name varchar(50) NOT NULL, address_id integer NULL, photo blob null)'
     ).then(function() {
+      return createTable("pets",
+        'create table if not exists pets (id integer primary key, name varchar(50) NOT NULL, owner_id integer NULL)'
+      );
+    }).then(function() {
       return createTable("people_addresses",
         'create table if not exists people_addresses(address_id integer NOT NULL, person_id integer NOT NULL, rating integer NULL)'
       );

--- a/test/describeDatabase.js
+++ b/test/describeDatabase.js
@@ -1413,6 +1413,7 @@ module.exports = function(name, config, database, otherTests) {
             var jane
             var jack
             var jessy
+            var smokey
             var miffy
 
             var somethingPlace = address({
@@ -1424,7 +1425,8 @@ module.exports = function(name, config, database, otherTests) {
                     address: address,
                     pets: function (owner) {
                       return [
-                        jessy = pet({name: 'jessy', owner: owner})
+                        jessy = pet({name: 'jessy', owner: owner}),
+                        smokey = pet({name: 'smokey', owner: owner})
                       ]
                     }
                   }),
@@ -1491,6 +1493,10 @@ module.exports = function(name, config, database, otherTests) {
                           {
                             id: jessy.id,
                             name: 'jessy'
+                          },
+                          {
+                            id: smokey.id,
+                            name: 'smokey'
                           }
                         ]
                       },

--- a/test/describeDatabase.js
+++ b/test/describeDatabase.js
@@ -523,20 +523,34 @@ module.exports = function(name, config, database, otherTests) {
             var personExplicitId = db.model({
               table: "people_explicit_id"
             });
+            var miffy
 
             var p = personExplicitId({
-              id: 1,
-              name: "bob"
+              id: 4,
+              name: "bob",
+              pet: function (person) {
+                return [
+                  miffy = pet({name: 'miffy', owner: person})
+                ]
+              }
             });
 
             return p.save().then(function() {
               return db.query("select * from people_explicit_id").then(function(people) {
                 expect(database.clean(people)).to.eql([{
-                  id: 1,
+                  id: 4,
                   name: "bob"
                 }]);
               });
-            });
+            }).then(function () {
+              return db.query("select * from pets").then(function(pets) {
+                expect(database.clean(pets)).to.eql([{
+                  id: miffy.id,
+                  name: 'miffy',
+                  owner_id: 4
+                }]);
+              });
+            })
           });
         });
 

--- a/test/mssqlSpec.js
+++ b/test/mssqlSpec.js
@@ -14,6 +14,10 @@ var database = {
     return createTable("people",
       'CREATE TABLE [dbo].[people]([id] [int] IDENTITY(1,1) NOT NULL, [name] [nvarchar](50) NOT NULL, [address_id] [int] NULL, photo varbinary(10) null)'
     ).then(function() {
+      return createTable("pets",
+        'CREATE TABLE [dbo].[pets]([id] [int] IDENTITY(1,1) NOT NULL, [name] [nvarchar](50) NOT NULL, [owner_id] [int] NULL)'
+      );
+    }).then(function() {
       return createTable("people_addresses",
         'CREATE TABLE [dbo].[people_addresses]([address_id] [int] NOT NULL, [person_id] [int] NOT NULL, [rating] [int] NULL)'
       );

--- a/test/mysqlSpec.js
+++ b/test/mysqlSpec.js
@@ -25,6 +25,10 @@ var database = {
     return createTable("people",
       'create table if not exists people (id serial NOT NULL, name varchar(50) NOT NULL, address_id int NULL, photo varbinary(10) null)'
     ).then(function() {
+      return createTable("pets",
+        'create table if not exists pets (id serial NOT NULL, name varchar(50) NOT NULL, owner_id int NULL)'
+      );
+    }).then(function() {
       return createTable("people_addresses",
         'create table if not exists people_addresses(address_id int NOT NULL, person_id int NOT NULL, rating int NULL)'
       );

--- a/test/oracleSpec.js
+++ b/test/oracleSpec.js
@@ -65,6 +65,10 @@ if (!process.env.TRAVIS) {
           'create table addresses(id number primary key, address varchar2(50) NOT NULL)'
         );
       }).then(function() {
+        return createTable("pets", "id",
+          'create table pets (id number primary key, name varchar2(50) NOT NULL, owner_id number NULL)'
+        );
+      }).then(function() {
         return createTable("people_weird_id", "weird_id",
           'create table people_weird_id(weird_id number primary key, name varchar2(50) NULL, address_weird_id int NULL)'
         );

--- a/test/postgresSpec.js
+++ b/test/postgresSpec.js
@@ -60,6 +60,10 @@ var database = {
     return createTable("people",
       'create table if not exists people (id serial NOT NULL, name varchar(50) NOT NULL, address_id int NULL, photo bytea null)'
     ).then(function () {
+      return createTable("pets",
+        'create table if not exists pets (id serial NOT NULL, name varchar(50) NOT NULL, owner_id int NULL)'
+      );
+    }).then(function () {
       return createTable("people_addresses",
         'create table if not exists people_addresses(address_id int NOT NULL, person_id int NOT NULL, rating int NULL)'
       );

--- a/test/sqliteSpec.js
+++ b/test/sqliteSpec.js
@@ -16,6 +16,10 @@ var database = {
         'create table if not exists people_addresses(address_id integer NOT NULL, person_id integer NOT NULL, rating integer NULL)'
       );
     }).then(function() {
+      return createTable("pets",
+        'create table if not exists pets(id integer primary key, name varchar(50) not null, owner_id integer NOT NULL)'
+      );
+    }).then(function() {
       return createTable("addresses",
         'create table if not exists addresses(id integer primary key, address varchar(50) NOT NULL)'
       );

--- a/websqlDriver.js
+++ b/websqlDriver.js
@@ -31,7 +31,7 @@ module.exports = function() {
               }
 
               if (options.insert) {
-                r.id = result.insertId
+                r.id = params.hasOwnProperty(options.id) ? params[options.id] : result.insertId
               }
 
               fulfil(r)


### PR DESCRIPTION
Allows you to write regular SQL queries, but load them into a graph of objects with relationships that you can then modify and save again.

* [x] one to many relationships
* [x] one to one relationships
* [ ] compound keys
* [ ] documentation

### graph definition

Defines the objects involved in the query, the field names and the relationships. Notice that `people` is an array, indicating that it's a one-to-many relationship.

```js
var graph = address({
  id: 'address_id',
  address: 'address',
  people: [
    person({
      id: 'person_id',
      name: 'name'
    })
  ]
})
```

### query

Pass the graph definition to `queryGraph` along with the query, and query params if necessary:

```js
var results = await db.queryGraph(graph, `
  select
    people.id as person_id,
    name,
    addresses.id as address_id,
    address
  from
    people
      join addresses
        on people.address_id = addresses.id
`)
```

### results

the above will produce something like this. These objects are sworm objects, so they can be modified and `.update()`'d as required.

```js
[
  {
    address: '1 something place',
    people: [
      {
        name: 'bob'
      },
      {
        name: 'jane'
      }
    ]
  },
  {
    address: '2 another place',
    people: [
      {
        name: 'jack'
      }
    ]
  }
]
```